### PR TITLE
Changements expérimentaux

### DIFF
--- a/UTComputer/Arguments.h
+++ b/UTComputer/Arguments.h
@@ -45,19 +45,31 @@ public:
         return oss.str();
     }
     /**
-     * @brief Cast d'un vecteur de pointeurs vers un vecteur de types pointés.
+     * @brief Upcasting d'un vecteur
      */
-    template <typename U>
-    operator Arguments<U>() const {
-        Arguments<U> dest;
-        for (auto arg : *this) {
+    template <typename U, typename std::enable_if<std::is_base_of<U, T>::value, T>::type>
+    operator Arguments<std::shared_ptr<U>>() const {
+        Arguments<std::shared_ptr<U>> dest;
+        for (auto& arg : *this) {
+            dest.push_back(arg);
+        }
+        return dest;
+    }
+
+    /**
+     * @brief Cast d'un vecteur de pointeurs vers un vecteur de pointeurs sur un type concret
+     */
+    template <typename U, typename std::enable_if<!std::is_abstract<U>::value, T>::type>
+    operator Arguments<std::shared_ptr<U>>() const {
+        Arguments<std::shared_ptr<U>> dest;
+        for (auto& arg : *this) {
             //Si le type réel de l'objet pointé est le même que le type destination, on n'appelle pas d'opérateur de cast
             if(auto ptr = std::dynamic_pointer_cast<U>(arg)) {
-                dest.push_back(*ptr);
+                dest.push_back(ptr);
             }
             //Sinon, il faut passer par l'opérateur de cast (explicite ou implicite)
             else {
-                dest.push_back((U)*arg);
+                dest.push_back(std::make_shared<U>((U)*arg));
             }
         }
         return dest;

--- a/UTComputer/Operation.cpp
+++ b/UTComputer/Operation.cpp
@@ -3,7 +3,7 @@
 #include "Manager.h"
 #include "UTException.h"
 
-Operation::Generic Operation::applyOperation(const std::shared_ptr<const Operation> &op, Generic args) {
+Operation::Generic Operation::applyOperation(const std::shared_ptr<const Operation> &op, Operation::Generic args) {
     //Tentative d'application de l'opération générique
     try {
         return op->eval(args);
@@ -59,7 +59,7 @@ Operation::Generic Operation::eval(Operation::Expressions) const {
     throw UTException("Operation not implemented for ExpressionLiteral.");
 }
 Operation::Generic PlusOperation::eval(Operation::Rationals args) const {
-    IntegerLiteral a = args.front().getNum(), b = args.front().getDen(), c = args.back().getNum(), d = args.back().getDen();
+    IntegerLiteral a = args.front()->getNum(), b = args.front()->getDen(), c = args.back()->getNum(), d = args.back()->getDen();
 
     //Calcul du résultat via le dénominateur commun : la simplification est déléguée à la fabrique.
     int num = a.getValue() * d.getValue() + b.getValue() * c.getValue();
@@ -68,15 +68,15 @@ Operation::Generic PlusOperation::eval(Operation::Rationals args) const {
 }
 
 Operation::Generic PlusOperation::eval(Operation::Reals args) const {
-    return {LiteralFactory::getInstance().makeLiteral(args.front().getValue() + args.back().getValue())};
+    return {LiteralFactory::getInstance().makeLiteral(args.front()->getValue() + args.back()->getValue())};
 }
 
 Operation::Generic PlusOperation::eval(Operation::Complexs args) const {
     std::shared_ptr<Literal> new_re, new_im;
     std::shared_ptr<NumericLiteral> res_re, res_im;
     //Appel du plus sur les autres opérations
-    new_re = applyOperation(shared_from_this(), {args.front().getRe(), args.back().getRe()}).front();
-    new_im = applyOperation(shared_from_this(), {args.front().getIm(), args.back().getIm()}).front();
+    new_re = applyOperation(shared_from_this(), {args.front()->getRe(), args.back()->getRe()}).front();
+    new_im = applyOperation(shared_from_this(), {args.front()->getIm(), args.back()->getIm()}).front();
     res_re = std::dynamic_pointer_cast<NumericLiteral>(new_re);
     res_im = std::dynamic_pointer_cast<NumericLiteral>(new_im);
     if(!(res_re && res_im)) throw UTException("Result of operation on real or imaginary part incompatible with complexs.");
@@ -84,25 +84,25 @@ Operation::Generic PlusOperation::eval(Operation::Complexs args) const {
 }
 
 Operation::Generic MulOperation::eval(Operation::Rationals args) const {
-    IntegerLiteral a = args.front().getNum(), b = args.front().getDen(), c = args.back().getNum(), d = args.back().getDen();
+    IntegerLiteral a = args.front()->getNum(), b = args.front()->getDen(), c = args.back()->getNum(), d = args.back()->getDen();
     int num = a.getValue() * c.getValue();
     int den = b.getValue() * d.getValue();
     return Operation::Generic{LiteralFactory::getInstance().makeLiteral(num, den)};
 }
 
 Operation::Generic MulOperation::eval(Operation::Reals args) const {
-    return {LiteralFactory::getInstance().makeLiteral(args.front().getValue() * args.back().getValue())};
+    return {LiteralFactory::getInstance().makeLiteral(args.front()->getValue() * args.back()->getValue())};
 }
 
 Operation::Generic MulOperation::eval(Operation::Complexs args) const {
     std::shared_ptr<Literal> new_re, new_im;
     std::shared_ptr<NumericLiteral> res_re, res_im;
     new_re = applyOperation(std::make_shared<MoinsOperation>(), \
-        {applyOperation(shared_from_this(), {args.front().getRe(), args.back().getRe()}).front(), \
-         applyOperation(shared_from_this(), {args.front().getIm(), args.back().getIm()}).front()}).front();
+        {applyOperation(shared_from_this(), {args.front()->getRe(), args.back()->getRe()}).front(), \
+         applyOperation(shared_from_this(), {args.front()->getIm(), args.back()->getIm()}).front()}).front();
     new_im = applyOperation(std::make_shared<PlusOperation>(), \
-        {applyOperation(shared_from_this(), {args.front().getRe(), args.back().getIm()}).front(), \
-         applyOperation(shared_from_this(), {args.front().getIm(), args.back().getRe()}).front()}).front();
+        {applyOperation(shared_from_this(), {args.front()->getRe(), args.back()->getIm()}).front(), \
+         applyOperation(shared_from_this(), {args.front()->getIm(), args.back()->getRe()}).front()}).front();
     res_re = std::dynamic_pointer_cast<NumericLiteral>(new_re);
     res_im = std::dynamic_pointer_cast<NumericLiteral>(new_im);
     if(!(res_re && res_im)) throw UTException("Result of operation on real or imaginary part incompatible with complexs.");
@@ -126,10 +126,15 @@ Operation::Generic MoinsOperation::eval(Operation::Generic args) const {
     return applyOperation(std::make_shared<PlusOperation>(), args);
 }
 
-Operation::Generic STOOperation::eval(Operation::Generic args) const {
-    // Verifier qu'on a bien une expression
-    throw UTException("test");
-    /*ExpressionLiteral exp = ExpressionLiteral(*args.back().get());
-    Manager::getInstance().addIdentifier(exp.toString(),args.front());
-    return {};*/
+Operation::Generic DivOperation::eval(Operation::Rationals args) const {
+    args.back() = LiteralFactory::getInstance().makeLiteral(args.back()->getDen().getValue(), args.back()->getNum().getValue());
+    return applyOperation(std::make_shared<MulOperation>(), args);
+}
+
+Operation::Generic DivOperation::eval(Operation::Reals args) const {
+
+}
+
+Operation::Generic DivOperation::eval(Operation::Complexs args) const {
+
 }

--- a/UTComputer/Operation.h
+++ b/UTComputer/Operation.h
@@ -25,11 +25,11 @@
 class Operation : public std::enable_shared_from_this<Operation> {
 protected:
     typedef Arguments<std::shared_ptr<Literal>> Generic;
-    typedef Arguments<IntegerLiteral> Integers;
-    typedef Arguments<RationalLiteral> Rationals;
-    typedef Arguments<ComplexLiteral> Complexs;
-    typedef Arguments<RealLiteral> Reals;
-    typedef Arguments<ExpressionLiteral> Expressions;
+    typedef Arguments<std::shared_ptr<IntegerLiteral>> Integers;
+    typedef Arguments<std::shared_ptr<RationalLiteral>> Rationals;
+    typedef Arguments<std::shared_ptr<ComplexLiteral>> Complexs;
+    typedef Arguments<std::shared_ptr<RealLiteral>> Reals;
+    typedef Arguments<std::shared_ptr<ExpressionLiteral>> Expressions;
     /**
      * @brief Opération générique sur des littérales typées dynamiquement.
      * @details Les sous-classes devraient redéfinir cette méthode dans trois cas :
@@ -134,9 +134,14 @@ class ComplexOperation : public Operation {
     Generic eval(Generic args) const override;
 };
 
-class STOOperation : public Operation {
-public:
-    Generic eval(Generic args) const override;
+/**
+ * @brief Un objet DivOperation implémente l'opération de division (rationnelle)
+ * @details Les littérales supportées sont RationalLiteral, RealLiteral et ComplexLiteral.
+ */
+class DivOperation : public Operation {
+    Generic eval(Rationals args) const override;
+    Generic eval(Reals args) const override;
+    Generic eval(Complexs args) const override;
 };
 
 #endif

--- a/UTComputer/OperatorManager.cpp
+++ b/UTComputer/OperatorManager.cpp
@@ -20,6 +20,7 @@ OperatorManager::OperatorManager() : minus_symbol("-") {
     operators.push_back(std::make_shared<SymbolicOperator>("-", 2, std::make_shared<MoinsOperation>(), true, 0)); //Soustraction
     operators.push_back(std::make_shared<SymbolicOperator>("*", 2, std::make_shared<MulOperation>(), true, 1)); //Multiplication
     operators.push_back(std::make_shared<SymbolicOperator>("$", 2, std::make_shared<ComplexOperation>(), true, 2)); //Complexe
+    operators.push_back(std::make_shared<SymbolicOperator>("/", 2, std::make_shared<DivOperation>(), true, 1)); //Division
 
     //Création des opérateurs parenthésés
     operators.push_back(std::make_shared<FunctionOperator>("NEG", 1, std::make_shared<NegOperation>(), true)); //Négation
@@ -57,7 +58,7 @@ std::vector<std::shared_ptr<Operator>> OperatorManager::getSymbolicOperators() c
 
 Arguments<std::shared_ptr<Literal>> OperatorManager::dispatchOperation(std::shared_ptr<Operator> op, Arguments<std::shared_ptr<Literal>> args) const {
     //0. Vérifications
-    if (op->getArity() != args.size()) throw TypeError("Wrong number of operands.", args);
+    if (op->getArity() != args.size()) throw OperationError(op, args, "Wrong number of operands.", );
 
     //1. Cas particuliers
     //1.1. Un objet LiteralExpression est présent dans les opérandes et l'opérateur est numérique : méthode membre.


### PR DESCRIPTION
- Utilisation de pointeurs quoi qu'il arrive dans les opérations pour
permettre un re-dispatch à partir de types concrèts;
- Utilisations des traits pour discriminer les classes abstraites pour
le cast dans Arguments.